### PR TITLE
Add test extrinsic curvature

### DIFF
--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -488,6 +488,67 @@ void test_compute_3d_spacetime_normal_vector(const DataVector& used_for_size) {
                                       make_shift<dim>(used_for_size)),
       spacetime_normal_vector);
 }
+void test_compute_1d_extrinsic_curvature(const DataVector& used_for_size) {
+  const size_t dim = 1;
+  const auto extrinsic_curvature = compute_extrinsic_curvature(
+      make_lapse(0.), make_shift<dim>(0.), make_deriv_shift<dim>(0.),
+      make_spatial_metric<dim>(0.), make_dt_spatial_metric<dim>(0.),
+      make_deriv_spatial_metric<dim>(0.));
+
+  CHECK(extrinsic_curvature.get(0, 0) == approx(17. / 6.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_extrinsic_curvature(
+          make_lapse(used_for_size), make_shift<dim>(used_for_size),
+          make_deriv_shift<dim>(used_for_size),
+          make_spatial_metric<dim>(used_for_size),
+          make_dt_spatial_metric<dim>(used_for_size),
+          make_deriv_spatial_metric<dim>(used_for_size)),
+      extrinsic_curvature);
+}
+void test_compute_2d_extrinsic_curvature(const DataVector& used_for_size) {
+  const size_t dim = 2;
+  const auto extrinsic_curvature = compute_extrinsic_curvature(
+      make_lapse(0.), make_shift<dim>(0.), make_deriv_shift<dim>(0.),
+      make_spatial_metric<dim>(0.), make_dt_spatial_metric<dim>(0.),
+      make_deriv_spatial_metric<dim>(0.));
+
+  CHECK(extrinsic_curvature.get(0, 0) == approx(65. / 6.));
+  CHECK(extrinsic_curvature.get(0, 1) == approx(97. / 6.));
+  CHECK(extrinsic_curvature.get(1, 1) == approx(22.0));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_extrinsic_curvature(
+          make_lapse(used_for_size), make_shift<dim>(used_for_size),
+          make_deriv_shift<dim>(used_for_size),
+          make_spatial_metric<dim>(used_for_size),
+          make_dt_spatial_metric<dim>(used_for_size),
+          make_deriv_spatial_metric<dim>(used_for_size)),
+      extrinsic_curvature);
+}
+void test_compute_3d_extrinsic_curvature(const DataVector& used_for_size) {
+  const size_t dim = 3;
+  const auto extrinsic_curvature = compute_extrinsic_curvature(
+      make_lapse(0.), make_shift<dim>(0.), make_deriv_shift<dim>(0.),
+      make_spatial_metric<dim>(0.), make_dt_spatial_metric<dim>(0.),
+      make_deriv_spatial_metric<dim>(0.));
+
+  CHECK(extrinsic_curvature.get(0, 0) == approx(79. / 3.));
+  CHECK(extrinsic_curvature.get(0, 1) == approx(235. / 6.));
+  CHECK(extrinsic_curvature.get(0, 2) == approx(52.0));
+  CHECK(extrinsic_curvature.get(1, 1) == approx(53.0));
+  CHECK(extrinsic_curvature.get(1, 2) == approx(2005. / 30.));
+  CHECK(extrinsic_curvature.get(2, 2) == approx(245. / 3.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_extrinsic_curvature(
+          make_lapse(used_for_size), make_shift<dim>(used_for_size),
+          make_deriv_shift<dim>(used_for_size),
+          make_spatial_metric<dim>(used_for_size),
+          make_dt_spatial_metric<dim>(used_for_size),
+          make_deriv_spatial_metric<dim>(used_for_size)),
+      extrinsic_curvature);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
@@ -514,4 +575,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
   test_compute_1d_spacetime_normal_vector(dv);
   test_compute_2d_spacetime_normal_vector(dv);
   test_compute_3d_spacetime_normal_vector(dv);
+  test_compute_1d_extrinsic_curvature(dv);
+  test_compute_2d_extrinsic_curvature(dv);
+  test_compute_3d_extrinsic_curvature(dv);
 }


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
